### PR TITLE
shadowとtypographyの変換処理に関するオプション追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "UNLICENSED",
   "author": "",
   "scripts": {
-    "token:token-transformer": "./node_modules/.bin/token-transformer tokens.json output.json",
+    "token:token-transformer": "./node_modules/.bin/token-transformer tokens.json output.json --expandShadow --expandTypography",
     "token:style-dictionary": "style-dictionary build --config style-dictionary.config.json",
     "token": "run-s token:token-transformer token:style-dictionary"
   },


### PR DESCRIPTION
## 概要
shadowやtypographyのトークンは現状`[object Object]`で出力されてしまい、cssやsassでは値が参照できない。
出力結果の形式として使い勝手が良いとは言えないがtoken-transformerの`--expandShadow` と`--expandTypography`でネストされたプロパティをフラットに展開することで値を参照できるようにする。

このPRにより以下のような無効なsassの変数が、
```scss
$typography-question-default: [object Object];
```
以下のように変換される。
```scss
$typography-question-default-font-family: 'Hiragino Sans';
$typography-question-default-font-weight: 300;
$typography-question-default-font-size: 22px;
$typography-question-default-line-height: 1.5rem;
```

## 特記事項
[こちらの記事](https://zenn.dev/helicoir/articles/9fb967b6b6e535#%E3%81%8A%E3%82%8F%E3%82%8A%E3%81%AB)のように、styledictionaryの設定を拡張してプロパティをフラットに展開せず、一括指定の形式に変換するやり方もある。
Style Dictionaryのconfigの拡張については[ドキュメント](https://amzn.github.io/style-dictionary/#/config?id=using-in-node)参照(build.jsのような拡張スクリプト用のファイルを作成してnodeコマンドで実行するイメージ)。
メンテナンス性も考えると自前でライブラリを拡張して使うのはリスクがあるので需要が出た時に改めて検討してもらいたい。